### PR TITLE
Fixing check digit calculation when it should be zero.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,8 @@ const ean13_generate = function(n) {
         }
         f = 3 == f ? 1 : 3;
     }
-    let d = 10 - (s % 10)
+    const remainder = s % 10;
+    const d = remainder === 0 ? 0 : 10 - remainder;
     n = n * 10 + d;
     return n;
 }


### PR DESCRIPTION
This pull request fixes the check digit calculation in the case it's supposed to be zero.

Before this pull request, in case `(s % 10)` was zero, then `d` would be `10`  because of `let d = 10 - (s % 10)`, what is wrong.

So the change is: in case `(s % 10)` is zero, then `d` should also be zero.